### PR TITLE
Tweak: Changed Output Directory

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -18,7 +18,7 @@ echo "Starting the HOPX Linux ISO build process..."
 mkdir -p "$OUTPUT_DIR"
 
 # Building with Archiso
-sudo mkarchiso -v -w "$WORK_DIR" -o "$OUTPUT_DIR" build
+sudo mkarchiso -v -w "$WORK_DIR" -o "$OUTPUT_DIR" .
 
 # End Message
 echo "HOPX Linux ISO build process has been completed."

--- a/build/packages.x86_64
+++ b/build/packages.x86_64
@@ -5,6 +5,7 @@
 base
 linux
 linux-firmware
+syslinux
 systemd
 grub
 bash
@@ -13,6 +14,7 @@ sudo
 
 ## Filesystems & Shell ##
 coreutils
+edk2-shell
 sed
 grep
 less

--- a/build/profiledef.sh
+++ b/build/profiledef.sh
@@ -20,7 +20,7 @@ install_dir="arch"
 build_modes=('iso')
 
 # Boot Mode
-bootmodes=('bios.syslinux.mbr' 'uefi-x64.systemd-boot.esp')
+bootmodes=('bios.syslinux' 'uefi-x64.systemd-boot')
 
 # Pacman Configuration
 pacman_conf="pacman.conf"


### PR DESCRIPTION
Tweak: Changed the output directory of the build file. Right now it caused too much problems regarding the building of the ISO and running the correlated profiledef.sh.

Besides that a few tweaks have been made to the packages file, it seems that I have used some packages that are out of date or not-exisiting anymore. I will need to dive in the docs again.